### PR TITLE
WIP: Paged search results

### DIFF
--- a/parks/views.py
+++ b/parks/views.py
@@ -104,7 +104,6 @@ def get_parks(request):
                 "pages": parks_pages.num_pages
             }
         else:
-            # FIXME: should this even be paged? There's nowhere to put the total # of pages...
             response_json = {p.pk: p.to_external_document(user, include_large=True) for p in parks}
 
         return HttpResponse(json.dumps(response_json), mimetype='application/json')


### PR DESCRIPTION
This is just a start right now and only includes changes to the API (no UI yet).

Some open questions:
- [x] What should the default page size be? Right now it's 5, but that's almost certainly too small. 10? 20? something else?
- [x] If `no_map` is `False`, should we still be paging? we'll need to modify the API to have a place to put the number of pages available in that case.
- [x] How do we do error handling in the API right now? `page` and `page_size` need to be ints, but `int()` will raise an exception if it can't parse.
- [ ] Should we preserve a way to get back **all** results instead of paged results? `page=0` or `page_size=infinity` or who knows what?
